### PR TITLE
raylib_game.cpp: add cmath include

### DIFF
--- a/game/src/raylib_game.cpp
+++ b/game/src/raylib_game.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <vector>
 #include <filesystem>
+#include <cmath>
 #include "raylib.h"
 #include "tinyfiledialogs.h"
 #include "NTBL.h"


### PR DESCRIPTION
This is needed for building with gcc, as it contains the declaration for the sqrt function.